### PR TITLE
[v1.1] remove label option

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -12,7 +12,7 @@
 
   // Optional: Automatically detect which branches a pull request should be backported to based on the pull request labels.
   // In this case, adding the label "auto-backport-to-production" will backport the PR to the "production" branch
-  "branchLabelMapping": {
-    "^backport-to-(.+)$": "$1"
-  }
+  // "branchLabelMapping": {
+  //  "^backport-to-(.+)$": "$1"
+  //}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v1.1`:
 - remove label option (5a2c5ecf)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)